### PR TITLE
feat: large surface

### DIFF
--- a/components/editor/popup.tsx
+++ b/components/editor/popup.tsx
@@ -296,7 +296,8 @@ const PopupEditor = (props: PopupEditorProps) => {
             <Textarea
               resize="both"
               style={{
-                width: "25vw",
+                width: "40vw",
+                minHeight: "5rem"
               }}
               placeholder="Add an optional note"
               value={popUpStore.note}

--- a/components/editor/popup.tsx
+++ b/components/editor/popup.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles({
     }
   },
   largeSurface: {
-    maxWidth: "80vw",
+    maxWidth: "98vw",
   }
 })
 
@@ -193,7 +193,7 @@ const PopupEditor = (props: PopupEditorProps) => {
                   }}
                   appearance="primary"
                 >
-                  Submit
+                  Save
                 </Button>
               </div>
             }
@@ -221,7 +221,7 @@ const PopupEditor = (props: PopupEditorProps) => {
                         popUpStore.setSourceSelectionRange([-1, -1])
                       }}
                     >
-                      Delete highlight
+                      Clear highlight
                     </Button>
                   }
                 />
@@ -255,7 +255,7 @@ const PopupEditor = (props: PopupEditorProps) => {
                             popUpStore.setSummarySelectionRange([-1, -1])
                           }}
                       >
-                          Delete highlight
+                          Clear highlight
                       </Button>
                   }
                 />
@@ -278,7 +278,7 @@ const PopupEditor = (props: PopupEditorProps) => {
             </div>
           </DialogContent>
 
-          <DialogActions position="end">
+          <DialogActions position="start">
             <CustomOption
               labels={props.labels}
               syncLabels={(labels) => {
@@ -290,6 +290,9 @@ const PopupEditor = (props: PopupEditorProps) => {
               }}
               key={forceUpdateKey}
             />
+          </DialogActions>
+
+          <DialogActions position="end">
             <Textarea
               resize="both"
               style={{


### PR DESCRIPTION
<img width="2550" alt="image" src="https://github.com/user-attachments/assets/9fcec03f-385e-410a-ad09-57640be12972" />

It is now 98% of the screen width, the options have been repositioned and the text has been adjusted.

PR for #23